### PR TITLE
Matching title case to resolve the non-displayin sample entries image

### DIFF
--- a/data-management-app/downloader/templates/app/downloader.html
+++ b/data-management-app/downloader/templates/app/downloader.html
@@ -51,7 +51,7 @@
 <div class="image-container">
 
 
-    <img class="sample-image entries" src="{{ url_for('static', filename='images/' + 'entries_sample.jpg') }}" >
+    <img class="sample-image entries" src="{{ url_for('static', filename='images/' + 'entries_sample.JPG') }}" >
     <img class="sample-image treatments" src="{{ url_for('static', filename='images/' + 'treatments_sample.jpg') }}" >
     <img class="sample-image profile" src="{{ url_for('static', filename='images/' + 'profiles_sample.jpg') }}" >
     <img class="sample-image device_status" src="{{ url_for('static', filename='images/' + 'device_sample.jpg') }}" >


### PR DESCRIPTION
(Or if you prefer, adjust the file name of the image to lowercase .jpg)

Right now, without this change, the entries sample image does not display. The others work fine. 